### PR TITLE
WIP: windows jenkins

### DIFF
--- a/windows/jenkins_packages_build.bat
+++ b/windows/jenkins_packages_build.bat
@@ -1,0 +1,28 @@
+rem Build Python and packages on the target machine
+rem Arguments:
+rem DEPENDENCIES_DIR=Path to dependencies
+
+pip install clint
+pip install coverage
+pip install nose
+pip install pytest
+pip install requests
+pip install virtualenv
+pip install wheel
+pip install %DEPENDENCIES_DIR%\Cython-0.23.4-cp27-none-win_amd64.whl
+pip install %DEPENDENCIES_DIR%\numpy-1.9.3+mkl-cp27-none-win_amd64.whl
+pip install %DEPENDENCIES_DIR%\wxPython-3.0.2.0-cp27-none-win_amd64.whl
+pip install %DEPENDENCIES_DIR%\wxPython_common-3.0.2.0-py2-none-any.whl
+pip install %DEPENDENCIES_DIR%\scipy-0.16.1-cp27-none-win_amd64.whl
+pip install %DEPENDENCIES_DIR%\pyzmq-15.1.0-cp27-none-win_amd64.whl
+pip install %DEPENDENCIES_DIR%\h5py-2.5.0-cp27-none-win_amd64.whl
+pip install %DEPENDENCIES_DIR%\MySQL_python-1.2.5-cp27-none-win_amd64.whl
+pip install %DEPENDENCIES_DIR%\matplotlib-1.5.0-cp27-none-win_amd64.whl
+pip install %DEPENDENCIES_DIR%\lxml-3.4.4-cp27-none-win_amd64.whl
+pip install %DEPENDENCIES_DIR%\py2exe-0.6.10a1-cp27-none-win_amd64.whl
+pip install %DEPENDENCIES_DIR%\PyOpenGL-3.1.1b1-cp27-none-win_amd64.whl
+pip install %DEPENDENCIES_DIR%\PyOpenGL_accelerate-3.1.1a1-cp27-none-win_amd64.whl
+pip install %DEPENDENCIES_DIR%\PyQt4-4.11.4-cp27-none-win_amd64.whl
+pip install %DEPENDENCIES_DIR%\qimage2ndarray-1.3.1-cp27-none-win_amd64.whl
+pip install %DEPENDENCIES_DIR%\scikit_learn-0.17-cp27-none-win_amd64.whl
+pip install %DEPENDENCIES_DIR%\scikit_image-0.11.3-cp27-none-win_amd64.whl

--- a/windows/readme.rst
+++ b/windows/readme.rst
@@ -1,0 +1,28 @@
+Setting up Jenkins
+
+Install the following curated dependencies:
+
+* VCForPython27.msi (install as administrator)
+  * Get an elevated (administrator) command prompt, e.g. open Windows Explorer
+  and navigate to c:\Windows\System32, right mouse button click on `cmd.exe`
+  and select `Run as Administrator`.
+  * msiexec /i VCForPython27.msi ALLUSERS=1
+  * it may be necessary to copy the binary to a local drive
+* python-2.7.10.amd64.msi
+* jdk-8u65-windows-x64.exe
+* Git-2.6.4-64-bit.exe (do not install explorer extensions, add GIT to path)
+* cmake-3.4.0-win32-x86.exe (add cmake to path)
+
+Unzip `jenkins-1.642.zip` and run jenkins.msi
+
+From the Git Bash command prompt:
+* cd to a temp directory
+* git clone https://github.com/LeeKamentsky/build-ilastik-on-windows
+
+From the VC for Python 2.7 64-bit command prompt:
+
+* Set the environment variable, DEPENDENCIES_DIR to the path to the curated
+dependencies.
+* Run the script, `jenkins_packages_build.bat`.
+* cd to the build-ilastik-on-windows directory
+* `python setup.py build`

--- a/windows/readme.rst
+++ b/windows/readme.rst
@@ -12,6 +12,7 @@ Install the following curated dependencies:
 * jdk-8u65-windows-x64.exe
 * Git-2.6.4-64-bit.exe (do not install explorer extensions, add GIT to path)
 * cmake-3.4.0-win32-x86.exe (add cmake to path)
+* isetup-5.5.6-unicode.exe
 
 Unzip `jenkins-1.642.zip` and run jenkins.msi
 
@@ -26,3 +27,12 @@ dependencies.
 * Run the script, `jenkins_packages_build.bat`.
 * cd to the build-ilastik-on-windows directory
 * `python setup.py build`
+
+If you have the license to redistribute the MSVCRT 9.0 DLL, you can copy the
+files from the Microsoft.VC90.CRT directory to the build machine and
+include them in the MSI with a build command like:
+
+    python setup.py py2exe --msvc-redist=<path-to-Microsoft.VC90.CRT> msi
+
+If you have MSVC 9.0 installed on your machine (by some miracle), the setup
+script will find the redistributables automatically.


### PR DESCRIPTION
The readme file is probably the biggest contribution to this PR.
jenkins_packages_build.bat does a good job of setting up the system Python with a stable set of packages (not centrosome / javabridge / bioformats / CellProfiler which may change and should be installed to a virtualenv). It even installs Ilastik.
